### PR TITLE
add project updates (changes to data.json) as feed, fix #27

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 	<link rel="stylesheet" type="text/css" href="css/default.css" />
 	<link rel="shortcut icon" href="images/favicon.png" />
 	<link rel="apple-touch-icon-precomposed" href="images/favicon-touch.png" />
+	<link rel="alternate" type="application/rss+xml" title="Libre Projects" href="https://github.com/libreprojects/libreprojects/commits/gh-pages/js/data.json.atom" />
 	<script type="text/javascript" src="js/jquery-1.7.1.min.js"></script>
 	<!--<script type="text/javascript" src="js/jquery.cookie.js"></script>-->
 	<!--script type="text/javascript" src="js/jquery.ba-dotimeout.min.js"></script-->


### PR DESCRIPTION
A simple solution to have an RSS feed on the page. This just shows the changes to the data.json file, as @jhuet suggested in #27. I think that’s better because simpler than having additional overhead via hooks or building a custom feed.
As you see the commit messages should be properly worded sentences, but that should be the case always.

Please review @libreprojects/contributors!
