### PR TITLE
Ensure all the html img elements have meaningful alt texts

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 	<script type="text/javascript" src="js/prefixfree.min.js"></script>
 </head>
 <body>
-<h1><a href="http://libreprojects.net"><img src="images/favicon-touch.png" alt="" /><span>Libre Projects</span></a></h1>
+<h1><a href="http://libreprojects.net"><img src="images/favicon-touch.png" alt="libreprojects logo" /><span>Libre Projects</span></a></h1>
 <p><span id="nb-projects"></span> <span class="translatable">open source hosted web services</span></p>
 
 <ul id="locale"></ul>

--- a/js/default.js
+++ b/js/default.js
@@ -419,6 +419,7 @@ lp = $.extend(lp, {
 					$details.find('.description').html(lp.actualProject.description);
 					$details.find('.category').attr('href', '#' + lp.actualProject.category).html(lp.actualProject.category).data('text', 'Check the ' + lp.actualProject.category + ' category');
 					$details.find('.logo').attr('src', 'logos/' + lp.actualProject.id + '.png');
+					$details.find('.logo').attr('alt', lp.actualProject.id);
 
 					var $tags = $details.find('.tags').html('');
 					if (lp.actualProject.tags && lp.actualProject.tags.length) {
@@ -626,7 +627,7 @@ $(document).ready(function() {
 		var $ul = $('<ul />').appendTo($categories);
 		$.each(lp.projects, function(pidx, project) {
 			if (category.id == project.category) {
-				$('<li id="' + project.id + '" />').html('<a href="' + project.address + '"><img src="logos/' + project.id + '.png" alt="" /><span class="project"><strong class="name">' + project.name + '</strong><span class="translatable">' + project.description + '</span></span><span class="star star-off"></span></a></li>')
+				$('<li id="' + project.id + '" />').html('<a href="' + project.address + '"><img src="logos/' + project.id + '.png" alt="' + project.id + ' logo" /><span class="project"><strong class="name">' + project.name + '</strong><span class="translatable">' + project.description + '</span></span><span class="star star-off"></span></a></li>')
 					   .data('category', category.id)
 					   .appendTo($ul);
 			}


### PR DESCRIPTION
esp. projects without logos should show project name
## Motivation

At the moment, identica (in “social”, after Freenode IRC) has no logo and thus the img element there refers to the nonexistent file logos/identica.png. With an appropriate alt attribution, the text would be shown in this case.
