### PR TITLE
update favorites: remove Cloud9, add Wikipedia & Wordpress

### DIFF
--- a/js/data.json
+++ b/js/data.json
@@ -201,7 +201,7 @@ var lp = {
 		{"id":"friendica","category":"social","name":"Friendica","description":"social multi network","address":"http://friendica.com/","licenses":["mit"],"tags":["social","network","decentralized","microblog"],"alternative":["facebook","google plus","twitter"],"introduction":"Friendica is is an open source, free social web server. Your 'friends' can be from Facebook, Diaspora, Twitter, Identi.ca, weblogs and RSS feeds - and even email.","source":"https://github.com/friendica/"},
 		{"id":"orion","category":"development","name":"Orion","description":"IDE","address":"http://orionhub.org/","licenses":["epl-v1"],"tags":["ide","cloud"],"introduction": "Open Source Platform For Cloud Based Development"},
 	],
-	"defaultFavorites" : ["joindiaspora-com", "owncloud", "openstreetmap", "jamendo", "cloud9", "plos"]
+	"defaultFavorites" : ["wikipedia", "joindiaspora-com", "owncloud", "wordpress", "openstreetmap", "jamendo", "plos"]
 };
 
 $(document).ready(function() {


### PR DESCRIPTION
Due to Cloud9 not being open source anymore (see https://github.com/libreprojects/libreprojects/pull/138 ) it can’t be in favorites obviously.

I also took that as the chance to finally move Wikipedia & Wordpress in there as they are prominent examples and they will help people understand what Libre Projects is about. :)

Please review @libreprojects/contributors @Thetoxicarcade (btw @Thetoxicarcade I can add you to the contributors group here, is that cool?)
